### PR TITLE
sqon elasticsearch mapper extensions

### DIFF
--- a/src/services/api/variant/schema/es/1.json
+++ b/src/services/api/variant/schema/es/1.json
@@ -20,7 +20,7 @@
           }
         }
       ],
-      "postprocess": "context.sort[0]['donors.exomiserScore'].nested.filter = { match: { 'donors.patientId': context.patient } }; return context.sort"
+      "postprocess": "context.sort[0]['donors.exomiserScore'].nested.filter = { term: { 'donors.patientId': context.patient } }; return context.sort"
     }
   },
   "defaultGroup": "impact",
@@ -34,7 +34,7 @@
           "label": "filter_variant_type",
           "type": "generic",
           "search": {
-            "variant_type": "type"
+            "variant_type": "type.keyword"
           },
           "facet": [
             {
@@ -56,7 +56,7 @@
           "label": "filter_consequence",
           "type": "generic",
           "search": {
-            "consequence": "consequences.consequence"
+            "consequence": "consequences.consequence.keyword"
           },
           "facet": [
             {
@@ -120,7 +120,7 @@
           "label": "filter_chromosome",
           "type": "generic",
           "search": {
-            "chromosome": "chrom"
+            "chromosome": "chrom.keyword"
           },
           "facet": [
             {
@@ -148,7 +148,7 @@
           "label": "filter_gene_type",
           "type": "generic",
           "search": {
-            "gene_type": "genes.biotype"
+            "gene_type": "genes.biotype.keyword"
           },
           "facet": [
             {
@@ -232,7 +232,7 @@
             }
           },
           "search": {
-            "gene_hpo": "genes.hpo"
+            "gene_hpo": "genes.hpo.keyword"
           },
           "facet": [
             {
@@ -254,7 +254,7 @@
           "label": "filter_genegroup_radboud",
           "type": "generic",
           "search": {
-            "genegroup_radboud": "genes.radboudumc"
+            "genegroup_radboud": "genes.radboudumc.keyword"
           },
           "facet": [
             {
@@ -276,7 +276,7 @@
           "label": "filter_genegroup_orphanet",
           "type": "generic",
           "search": {
-            "genegroup_orphanet": "genes.orphanet"
+            "genegroup_orphanet": "genes.orphanet.keyword"
           },
           "facet": [
             {
@@ -304,7 +304,7 @@
           "label": "filter_exomiser_score",
           "type": "numcomparison",
           "search": {
-            "exomiser_score": "donors.exomiserScore"
+            "exomiser_score": "donors.exomiserScore.keyword"
           },
           "facet": [
             {
@@ -330,7 +330,7 @@
           "label": "filter_clinvar_clinsig",
           "type": "generic",
           "search": {
-            "clinvar_clinsig": "clinvar.clinvar_clinsig"
+            "clinvar_clinsig": "clinvar.clinvar_clinsig.keyword"
           },
           "facet": [
             {
@@ -352,7 +352,7 @@
           "label": "filter_impacts",
           "type": "generic",
           "search": {
-            "impact": "consequences.impact"
+            "impact": "consequences.impact.keyword"
           },
           "facet": [
             {
@@ -376,7 +376,7 @@
           "search": {
             "prediction_fathmm": {
               "score": "consequences.predictions.FATHMM_score",
-              "quality": "consequences.predictions.FATHMM"
+              "quality": "consequences.predictions.FATHMM.keyword"
             }
           },
           "facet": [
@@ -417,7 +417,7 @@
           "search": {
             "prediction_sift": {
               "score": "consequences.predictions.SIFT_score",
-              "quality": "consequences.predictions.SIFT"
+              "quality": "consequences.predictions.SIFT.keyword"
             }
           },
           "facet": [
@@ -458,7 +458,7 @@
           "search": {
             "prediction_polyphen2_hvar": {
               "score": "consequences.predictions.Polyphen2_HVAR_score",
-              "quality": "consequences.predictions.Polyphen2_HVAR_pred"
+              "quality": "consequences.predictions.Polyphen2_HVAR_pred.keyword"
             }
           },
           "facet": [
@@ -499,7 +499,7 @@
           "search": {
             "prediction_lrt": {
               "score": "consequences.predictions.LRT_score",
-              "quality": "consequences.predictions.LRT_pred"
+              "quality": "consequences.predictions.LRT_pred.keyword"
             }
           },
           "facet": [
@@ -792,7 +792,7 @@
           "label": "filter_transmission",
           "type": "generic",
           "search": {
-            "transmission": "donors.zygosity"
+            "transmission": "donors.zygosity.keyword"
           },
           "facet": [
             {

--- a/src/services/api/variant/schema/es/1.json
+++ b/src/services/api/variant/schema/es/1.json
@@ -5,8 +5,8 @@
   "path": "/mutations",
   "fields": {
     "patient": "donors.patientId.keyword",
-    "practitioner": "donors.practitionerId",
-    "organization": "donors.organizationId"
+    "practitioner": "donors.practitionerId.keyword",
+    "organization": "donors.organizationId.keyword"
   },
   "groups": {
     "impact": {
@@ -25,7 +25,7 @@
           }
         }
       ],
-      "postprocess": "context.sort[0]['donors.exomiserScore'].nested.filter = { term: { 'donors.patientId': context.patient } }; return context.sort"
+      "postprocess": "context.sort[0]['donors.exomiserScore'].nested.filter = { term: { 'donors.patientId.keyword': context.patient } }; return context.sort"
     }
   },
   "defaultGroup": "impact",

--- a/src/services/api/variant/schema/es/1.json
+++ b/src/services/api/variant/schema/es/1.json
@@ -3,6 +3,11 @@
   "dialect": "es",
   "index": "clin-mutation-centric",
   "path": "/mutations",
+  "fields": {
+    "patient": "donors.patientId.keyword",
+    "practitioner": "donors.practitionerId",
+    "organization": "donors.organizationId"
+  },
   "groups": {
     "impact": {
       "sort": [

--- a/src/services/api/variant/schema/gql/1.json
+++ b/src/services/api/variant/schema/gql/1.json
@@ -3,13 +3,18 @@
   "dialect": "gql",
   "index": "",
   "path": "",
+  "fields": {
+    "patient": "",
+    "practitioner": "",
+    "organization": ""
+  },
   "groups": {
-    "impact": {
+    "score": {
       "sort": [],
       "postprocess": ""
     }
   },
-  "defaultGroup": "impact",
+  "defaultGroup": "score",
   "categories": [
     {
       "id": "variant",
@@ -19,6 +24,7 @@
           "id": "variant_type",
           "label": "filter_variant_type",
           "type": "generic",
+          "config": {},
           "search": {},
           "facet": []
         }

--- a/src/services/api/variant/sqon/dialect/es.js
+++ b/src/services/api/variant/sqon/dialect/es.js
@@ -207,10 +207,10 @@ const translateToElasticSearch = ( query, options, getFieldSearchNameFromId ) =>
     const instructions = mapInstructions( query.instructions )
     const translation = postMapInstructions( instructions )
 
-    return { query: { bool: { filter: { bool: { must: [ translation ] } } } } }
+    return { query: { bool: { filter: [ translation ] } } }
 }
 
 export const elasticSearchTranslator = {
     translate: translateToElasticSearch,
-    emptyTranslation: { query: { bool: { filter: { bool: { must: [] } } } } }
+    emptyTranslation: { query: { bool: { filter: [] } } }
 }

--- a/src/services/api/variant/sqon/dialect/es.js
+++ b/src/services/api/variant/sqon/dialect/es.js
@@ -207,10 +207,10 @@ const translateToElasticSearch = ( query, options, getFieldSearchNameFromId ) =>
     const instructions = mapInstructions( query.instructions )
     const translation = postMapInstructions( instructions )
 
-    return { query: translation }
+    return { query: { bool: { filter: { bool: { must: [ translation ] } } } } }
 }
 
 export const elasticSearchTranslator = {
     translate: translateToElasticSearch,
-    emptyTranslation: { query: { bool: {} } }
+    emptyTranslation: { query: { bool: { filter: { bool: { must: [] } } } } }
 }

--- a/src/services/api/variant/sqon/dialect/es.js
+++ b/src/services/api/variant/sqon/dialect/es.js
@@ -59,10 +59,7 @@ const mapGenericFilterInstruction = ( instruction, fieldMap ) => {
         [ getVerbFromOperand( instruction.data.operand ) ]: instruction.data.values.reduce(
             ( accumulator, value ) => {
                 accumulator.push(
-                    { match: { [ fieldMap ]: {
-                        query: value,
-                        operator: 'and'
-                    } } }
+                    { term: { [ fieldMap ]: value } }
                 )
                 return accumulator
             }, [] )
@@ -74,10 +71,7 @@ const mapSpecificFilterInstruction = ( instruction, fieldMap ) => {
         [ getVerbFromOperand( instruction.data.operand ) ]: instruction.data.values.reduce(
             ( accumulator, value ) => {
                 accumulator.push(
-                    { match: { [ fieldMap ]: {
-                        query: value,
-                        operator: 'and'
-                    } } }
+                    { term: { [ fieldMap ]: value } }
                 )
                 return accumulator
             }, [] )
@@ -103,9 +97,7 @@ const mapGenericBooleanFilterInstruction = ( instruction, fieldMap ) => {
     return {
         should: instruction.data.values.reduce( ( accumulator, group ) => {
             accumulator.push(
-                { match: { [ fieldMap[ group ] ]: {
-                    query: true
-                } } }
+                { term: { [ fieldMap[ group ] ]: true } }
             )
             return accumulator
         }, [] )
@@ -127,10 +119,7 @@ const mapCompositeFilterInstruction = ( instruction, fieldMap ) => {
     }
 
     return { must: {
-        match: { [ ( fieldMap.quality || fieldMap[ group.id ].quality ) ]: {
-            query: group.value,
-            operator: 'and'
-        } }
+        term: { [ ( fieldMap.quality || fieldMap[ group.id ].quality ) ]: group.value }
     } }
 }
 

--- a/src/services/api/variant/v1.js
+++ b/src/services/api/variant/v1.js
@@ -104,7 +104,7 @@ const getFacets = async ( req, res, cacheService, elasticService, logService ) =
                         const filtererdCategoryData = response.aggregations.filtered[ category ]
 
                         if ( filtererdCategoryData.value !== undefined ) {
-                            aggs[ category ] = [ { value: filtererdCategoryData.value } ]
+                            aggs[ category ] = [ { value: Number( filtererdCategoryData.value ) } ]
                         } else {
                             aggs[ category ] = filtererdCategoryData.buckets.reduce( ( accumulator, bucket ) => {
                                 return [ ...accumulator, { value: bucket.key, count: bucket.doc_count } ]
@@ -118,11 +118,11 @@ const getFacets = async ( req, res, cacheService, elasticService, logService ) =
                 responseFacetKeys = Object.keys( response.aggregations )
                 if ( responseFacetKeys.length > 0 ) {
                     responseFacetKeys.forEach( ( category ) => {
-                        const unfilteredCategoryData = response.aggregations[ category ][ category ]
+                        const unfilteredCategoryData = response.aggregations[ category ]
 
                         if ( unfilteredCategoryData.value !== undefined ) {
-                            facetsFromResponse[ category ] = [ { value: unfilteredCategoryData.value } ]
-                        } else {
+                            facetsFromResponse[ category ] = [ { value: Number( unfilteredCategoryData.value ) } ]
+                        } else if ( response.aggregations[ category ][ category ] !== undefined ) {
                             facetsFromResponse[ category ] = response.aggregations[ category ][ category ].buckets.reduce( ( accumulator, bucket ) => {
                                 return [ ...accumulator, { value: bucket.key, count: bucket.doc_count } ]
                             }, [] )

--- a/src/services/elastic.js
+++ b/src/services/elastic.js
@@ -148,12 +148,6 @@ export default class ElasticClient {
             filtered: { aggs: {} }
         }
 
-        if ( filter.length > 0 ) {
-            request.query.bool.filter.bool.must.push( filter )
-        }
-
-        request.query.bool.filter.bool.must.push( { term: { [ schema.fields.patient ]: patient } } )
-
         aggs.filtered.filter = request.query.bool.filter
         aggs.filtered.aggs = schemaFacets.reduce( ( accumulator, agg ) => {
             agg.facet.forEach( ( facet ) => {
@@ -161,6 +155,12 @@ export default class ElasticClient {
             } )
             return accumulator
         }, {} )
+
+        if ( filter.length > 0 ) {
+            request.query.bool.filter.bool.must.push( filter )
+        }
+
+        request.query.bool.filter.bool.must.push( { term: { [ schema.fields.patient ]: patient } } )
 
         const getSearchFieldNameFromFieldId = getFieldSearchNameFromFieldIdMappingFunction( schema )
         const getFacetFieldNameFromFieldId = getFieldFacetNameFromFieldIdMappingFunction( schema )
@@ -219,8 +219,6 @@ export default class ElasticClient {
                 }
             }
         } )
-
-        request.query.bool.filter.bool.must.push( filter )
 
         const body = {
             size: 0,

--- a/src/services/elastic.js
+++ b/src/services/elastic.js
@@ -115,10 +115,10 @@ export default class ElasticClient {
         }
 
         if ( filter.length > 0 ) {
-            request.query.bool.filter.bool.must.push( filter )
+            request.query.bool.filter.push( filter )
         }
 
-        request.query.bool.filter.bool.must.push( { term: { [ schema.fields.patient ]: patient } } )
+        request.query.bool.filter.push( { term: { [ schema.fields.patient ]: patient } } )
 
         const body = {
             from: index,
@@ -148,7 +148,6 @@ export default class ElasticClient {
             filtered: { aggs: {} }
         }
 
-        aggs.filtered.filter = request.query.bool.filter
         aggs.filtered.aggs = schemaFacets.reduce( ( accumulator, agg ) => {
             agg.facet.forEach( ( facet ) => {
                 accumulator[ [ facet.id ] ] = facet.query
@@ -156,11 +155,7 @@ export default class ElasticClient {
             return accumulator
         }, {} )
 
-        if ( filter.length > 0 ) {
-            request.query.bool.filter.bool.must.push( filter )
-        }
-
-        request.query.bool.filter.bool.must.push( { term: { [ schema.fields.patient ]: patient } } )
+        /* aggs.filtered.filter = request.query.bool.filter */
 
         const getSearchFieldNameFromFieldId = getFieldSearchNameFromFieldIdMappingFunction( schema )
         const getFacetFieldNameFromFieldId = getFieldFacetNameFromFieldIdMappingFunction( schema )
@@ -220,6 +215,12 @@ export default class ElasticClient {
             }
         } )
 
+        if ( filter.length > 0 ) {
+            request.query.bool.filter.push( filter )
+        }
+
+        request.query.bool.filter.push( { term: { [ schema.fields.patient ]: patient } } )
+
         const body = {
             size: 0,
             query: request.query,
@@ -233,6 +234,8 @@ export default class ElasticClient {
             json: true,
             body
         } )
+        */
+        return {}
     }
 
     async countVariantsForPatient( patient, request, acl, schema, group ) {
@@ -255,10 +258,10 @@ export default class ElasticClient {
         }
 
         if ( filter.length > 0 ) {
-            request.query.bool.filter.bool.must.push( filter )
+            request.query.bool.filter.push( filter )
         }
 
-        request.query.bool.filter.bool.must.push( { term: { [ schema.fields.patient ]: patient } } )
+        request.query.bool.filter.push( { term: { [ schema.fields.patient ]: patient } } )
 
         const body = {
             query: request.query

--- a/src/services/elastic.js
+++ b/src/services/elastic.js
@@ -22,7 +22,7 @@ const generateAclFilters = ( acl, service, schema = null ) => {
             if ( service === SERVICE_TYPE_PATIENT ) {
                 filters.push( { match: { 'practitioners.id': practitionerId } } )
             } else if ( service === SERVICE_TYPE_VARIANT ) {
-                filters.push( { match: { [ schema.fields.practitioner ]: practitionerId } } )
+                filters.push( { term: { [ schema.fields.practitioner ]: practitionerId } } )
             } else if ( service === SERVICE_TYPE_META ) {
                 filters.push( { match: { practitionerId } } )
             }
@@ -32,7 +32,7 @@ const generateAclFilters = ( acl, service, schema = null ) => {
             if ( service === SERVICE_TYPE_PATIENT ) {
                 filters.push( { match: { 'organization.id': organizationId } } )
             } else if ( service === SERVICE_TYPE_VARIANT ) {
-                filters.push( { match: { [ schema.fields.organization ]: organizationId } } )
+                filters.push( { term: { [ schema.fields.organization ]: organizationId } } )
             } else if ( service === SERVICE_TYPE_META ) {
                 filters.push( { match: { practitionerId } } )
             }


### PR DESCRIPTION
Major speed and accuracy improvements. :)

Changes only apply to code related to the **variant service**:
- conversion from scientific to numerical notation when relevant
- all `should` operations must include `minimum_should_match = 1`
- replace all match types with term types
- replace all filter types of `donors.patientId` with term types for variant search/aggs
- replace all acl filter types
- relevant match -> term type fields from `fieldname` to `fieldname.keyword`
- `patient`, `practitioner` and `organization` fields configurable in schema
- `aggregations` moved inside `filter` context for increased performance