### PR TITLE
enh/nested subtypes

### DIFF
--- a/src/services/api/variant/schema/es/1.json
+++ b/src/services/api/variant/schema/es/1.json
@@ -848,6 +848,12 @@
           "id": "transmission",
           "label": "filter_transmission",
           "type": "generic",
+          "subtype": {
+            "type": "nested",
+            "config": {
+              "path": "donors"
+            }
+          },
           "search": {
             "transmission": "donors.zygosity.keyword"
           },

--- a/src/services/api/variant/schema/es/1.json
+++ b/src/services/api/variant/schema/es/1.json
@@ -558,6 +558,10 @@
           "id": "prediction_dann",
           "label": "filter_prediction_dann",
           "type": "numcomparison",
+          "config": {
+            "min": "prediction_dann_min",
+            "max": "prediction_dann_max"
+          },
           "search": {
             "prediction_dann": "consequences.predictions.DANN_score"
           }

--- a/src/services/api/variant/schema/es/1.json
+++ b/src/services/api/variant/schema/es/1.json
@@ -855,7 +855,8 @@
           "subtype": {
             "type": "nested",
             "config": {
-              "path": "donors"
+              "path": "donors",
+              "field": "patientId.keyword"
             }
           },
           "search": {

--- a/src/services/api/variant/schema/gql/1.json
+++ b/src/services/api/variant/schema/gql/1.json
@@ -24,6 +24,12 @@
           "id": "variant_type",
           "label": "filter_variant_type",
           "type": "generic",
+          "subtype": {
+            "type": "nested",
+            "config": {
+              "path": "pathname"
+            }
+          },
           "config": {},
           "search": {},
           "facet": []

--- a/src/services/api/variant/sqon/dialect/es.js
+++ b/src/services/api/variant/sqon/dialect/es.js
@@ -61,10 +61,20 @@ const filterSubtypeIsNested = ( subtypeMap ) => {
 }
 
 const mutateMappedInstructionIntoNestedSubtype = ( mappedInstruction, subtypeMap ) => {
+    const filters = []
+
+    if ( subtypeMap.config.field ) {
+        filters.push( { term: { [ `${subtypeMap.config.path}.${subtypeMap.config.field}` ]: `%${subtypeMap.config.field}%` } } )
+    }
+
     return { must: [ {
         nested: {
             path: subtypeMap.config.path,
-            query: { bool: { filter: [ { bool: mappedInstruction } ] } }
+            query: {
+                bool: {
+                    filter: filters.concat( [ { bool: mappedInstruction } ] )
+                }
+            }
         }
     } ] }
 }

--- a/src/services/api/variant/sqon/dialect/es.js
+++ b/src/services/api/variant/sqon/dialect/es.js
@@ -10,7 +10,6 @@ import {
     instructionIsFilter,
     traverseObjectAndApplyFunc,
     getInstructionType
-
 } from '../index'
 
 

--- a/src/services/api/variant/sqon/dialect/gql.js
+++ b/src/services/api/variant/sqon/dialect/gql.js
@@ -58,23 +58,23 @@ const getVerbFromNumericalComparator = ( comparator ) => {
     }
 }
 
-const mapGenericFilterInstruction = ( instruction, fieldMap ) => {
+const mapGenericFilterInstruction = ( instruction, fieldMap, facetMap, subtypeMap ) => {
     return {}
 }
 
-const mapSpecificFilterInstruction = ( instruction, fieldMap ) => {
+const mapSpecificFilterInstruction = ( instruction, fieldMap, facetMap, subtypeMap ) => {
     return {}
 }
 
-const mapNumericalComparisonFilterInstruction = ( instruction, fieldMap ) => {
+const mapNumericalComparisonFilterInstruction = ( instruction, fieldMap, facetMap, subtypeMap ) => {
     return {}
 }
 
-const mapGenericBooleanFilterInstruction = ( instruction, fieldMap ) => {
+const mapGenericBooleanFilterInstruction = ( instruction, fieldMap, facetMap, subtypeMap ) => {
     return {}
 }
 
-const mapCompositeFilterInstruction = ( instruction, fieldMap ) => {
+const mapCompositeFilterInstruction = ( instruction, fieldMap, facetMap, subtypeMap ) => {
     const group = instruction.data
     const isNumericalComparison = !!group.comparator
 
@@ -86,24 +86,26 @@ const mapCompositeFilterInstruction = ( instruction, fieldMap ) => {
 }
 
 
-const translateToGraphQl = ( query, options, getFieldNameFromId ) => {
+const translateToGraphQl = ( query, options, getFieldSearchNameFromId, getFieldFacetNameFromId, getFieldSubtypeFromId ) => {
 
     const mapPartFromFilter = ( instruction, fieldId ) => {
         const type = getInstructionType( instruction )
-        const fieldMap = getFieldNameFromId( fieldId )
+        const fieldMap = getFieldSearchNameFromId( fieldId )
+        const facetMap = getFieldFacetNameFromId( fieldId )
+        const subtypeMap = getFieldSubtypeFromId( fieldId )
 
         switch ( type ) {
             default:
             case FILTER_TYPE_GENERIC:
-                return mapGenericFilterInstruction( instruction, fieldMap )
+                return mapGenericFilterInstruction( instruction, fieldMap, facetMap, subtypeMap )
             case FILTER_TYPE_SPECIFIC:
-                return mapSpecificFilterInstruction( instruction, fieldMap )
+                return mapSpecificFilterInstruction( instruction, fieldMap, facetMap, subtypeMap )
             case FILTER_TYPE_NUMERICAL_COMPARISON:
-                return mapNumericalComparisonFilterInstruction( instruction, fieldMap )
+                return mapNumericalComparisonFilterInstruction( instruction, fieldMap, facetMap, subtypeMap )
             case FILTER_TYPE_GENERIC_BOOLEAN:
-                return mapGenericBooleanFilterInstruction( instruction, fieldMap )
+                return mapGenericBooleanFilterInstruction( instruction, fieldMap, facetMap, subtypeMap )
             case FILTER_TYPE_COMPOSITE:
-                return mapCompositeFilterInstruction( instruction, fieldMap )
+                return mapCompositeFilterInstruction( instruction, fieldMap, facetMap, subtypeMap )
         }
     }
 

--- a/src/services/api/variant/sqon/index.js
+++ b/src/services/api/variant/sqon/index.js
@@ -204,6 +204,16 @@ export const getFieldFacetNameFromFieldIdMappingFunction = ( schema ) => {
     }
 }
 
+export const getFieldSubtypeFromFieldIdMappingFunction = ( schema ) => {
+    const flattenedSchema = flattenSchema( schema )
+
+    return ( id ) => {
+        const schemaFilter = find( flattenedSchema, { id } )
+
+        return schemaFilter.subtype ? schemaFilter.subtype[ [ id ] ] || schemaFilter.subtype : null
+    }
+}
+
 export const getInstructionType = ( instruction ) => {
     return instruction.data.type
 }
@@ -233,8 +243,9 @@ const translate = ( statement, queryKey, schema, dialect, dialectOptions ) => {
         const denormalizedQuery = getQueryByKey( denormalizedStatement, queryKey )
         const getFieldSearchNameFromFieldId = getFieldSearchNameFromFieldIdMappingFunction( schema )
         const getFieldFacetNameFromFieldId = getFieldFacetNameFromFieldIdMappingFunction( schema )
+        const getFieldSubtypeFromFieldId = getFieldSubtypeFromFieldIdMappingFunction( schema )
 
-        return translator.translate( denormalizedQuery, options, getFieldSearchNameFromFieldId, getFieldFacetNameFromFieldId )
+        return translator.translate( denormalizedQuery, options, getFieldSearchNameFromFieldId, getFieldFacetNameFromFieldId, getFieldSubtypeFromFieldId )
     }
 
     return null

--- a/src/services/api/variant/v1.js
+++ b/src/services/api/variant/v1.js
@@ -100,12 +100,12 @@ const getFacets = async ( req, res, cacheService, elasticService, logService ) =
                     delete response.aggregations.filtered.meta
                     delete response.aggregations.filtered.doc_count
                     facetsFromResponse = Object.keys( response.aggregations.filtered ).reduce( ( aggs, category ) => {
-                        const filtererdCategoryData = response.aggregations.filtered[ category ]
+                        const filteredCategoryData = response.aggregations.filtered[ category ]
 
-                        if ( filtererdCategoryData.value !== undefined ) {
-                            aggs[ category ] = [ { value: Number( filtererdCategoryData.value ) } ]
+                        if ( filteredCategoryData.value !== undefined ) {
+                            aggs[ category ] = [ { value: Number( filteredCategoryData.value ) } ]
                         } else {
-                            aggs[ category ] = filtererdCategoryData.buckets.reduce( ( accumulator, bucket ) => {
+                            aggs[ category ] = filteredCategoryData.buckets.reduce( ( accumulator, bucket ) => {
                                 return [ ...accumulator, { value: bucket.key, count: bucket.doc_count } ]
                             }, [] )
                         }

--- a/src/services/api/variant/v1.js
+++ b/src/services/api/variant/v1.js
@@ -99,7 +99,6 @@ const getFacets = async ( req, res, cacheService, elasticService, logService ) =
                 if ( response.aggregations.filtered ) {
                     delete response.aggregations.filtered.meta
                     delete response.aggregations.filtered.doc_count
-
                     facetsFromResponse = Object.keys( response.aggregations.filtered ).reduce( ( aggs, category ) => {
                         const filtererdCategoryData = response.aggregations.filtered[ category ]
 
@@ -120,8 +119,8 @@ const getFacets = async ( req, res, cacheService, elasticService, logService ) =
                     responseFacetKeys.forEach( ( category ) => {
                         const unfilteredCategoryData = response.aggregations[ category ]
 
-                        if ( unfilteredCategoryData.value !== undefined ) {
-                            facetsFromResponse[ category ] = [ { value: Number( unfilteredCategoryData.value ) } ]
+                        if ( unfilteredCategoryData[ category ].value !== undefined ) {
+                            facetsFromResponse[ category ] = [ { value: Number( unfilteredCategoryData[ category ].value ) } ]
                         } else if ( response.aggregations[ category ][ category ] !== undefined ) {
                             facetsFromResponse[ category ] = response.aggregations[ category ][ category ].buckets.reduce( ( accumulator, bucket ) => {
                                 return [ ...accumulator, { value: bucket.key, count: bucket.doc_count } ]

--- a/src/services/elastic.js
+++ b/src/services/elastic.js
@@ -247,7 +247,7 @@ export default class ElasticClient {
 
         query.bool.filter.push( { term: { [ schema.fields.patient ]: patient } } )
 
-        let stringifiedQuery = JSON.stringify( request.query )
+        let stringifiedQuery = JSON.stringify( query )
 
         stringifiedQuery = stringifiedQuery.replace( '%patientId.keyword%', patient )
 

--- a/src/services/elastic.js
+++ b/src/services/elastic.js
@@ -12,6 +12,12 @@ import {
 import { elasticSearchTranslator } from './api/variant/sqon/dialect/es'
 
 
+const replacePlaceholderInJSON = ( query, placeholder, placeholderValue ) => {
+    return JSON.parse(
+        JSON.stringify( query ).split( placeholder ).join( placeholderValue )
+    )
+}
+
 const generateAclFilters = ( acl, service, schema = null ) => {
     const filters = []
     const practitionerId = acl.practitioner_id
@@ -121,14 +127,10 @@ export default class ElasticClient {
 
         request.query.bool.filter.push( { term: { [ schema.fields.patient ]: patient } } )
 
-        let stringifiedQuery = JSON.stringify( request.query )
-
-        stringifiedQuery = stringifiedQuery.replace( '%patientId.keyword%', patient )
-
         const body = {
             from: index,
             size: limit,
-            query: JSON.parse( stringifiedQuery ),
+            query: replacePlaceholderInJSON( request.query, '%patientId.keyword%', patient ),
             sort
         }
 
@@ -247,14 +249,10 @@ export default class ElasticClient {
 
         query.bool.filter.push( { term: { [ schema.fields.patient ]: patient } } )
 
-        let stringifiedAggs = JSON.stringify( aggs )
-
-        stringifiedAggs = stringifiedAggs.replace( '%patientId.keyword%', aggs )
-
         const body = {
             size: 0,
-            query,
-            aggs: JSON.parse( stringifiedAggs )
+            query: replacePlaceholderInJSON( query, '%patientId.keyword%', patient ),
+            aggs: replacePlaceholderInJSON( aggs, '%patientId.keyword%', patient )
         }
 
         console.debug( JSON.stringify( body ) )
@@ -292,12 +290,8 @@ export default class ElasticClient {
 
         request.query.bool.filter.push( { term: { [ schema.fields.patient ]: patient } } )
 
-        let stringifiedQuery = JSON.stringify( request.query )
-
-        stringifiedQuery = stringifiedQuery.replace( '%patientId.keyword%', patient )
-
         const body = {
-            query: JSON.parse( stringifiedQuery )
+            query: replacePlaceholderInJSON( request.query, '%patientId.keyword%', patient )
         }
 
         console.debug( JSON.stringify( body ) )

--- a/src/services/elastic.js
+++ b/src/services/elastic.js
@@ -121,14 +121,19 @@ export default class ElasticClient {
 
         request.query.bool.filter.push( { term: { [ schema.fields.patient ]: patient } } )
 
+        let stringifiedQuery = JSON.stringify( request.query )
+
+        stringifiedQuery = stringifiedQuery.replace( '%patientId.keyword%', patient )
+
         const body = {
             from: index,
             size: limit,
-            query: request.query,
+            query: JSON.parse( stringifiedQuery ),
             sort
         }
 
         console.debug( JSON.stringify( body ) )
+
         return rp( {
             method: 'POST',
             uri,
@@ -242,13 +247,18 @@ export default class ElasticClient {
 
         query.bool.filter.push( { term: { [ schema.fields.patient ]: patient } } )
 
+        let stringifiedQuery = JSON.stringify( request.query )
+
+        stringifiedQuery = stringifiedQuery.replace( '%patientId.keyword%', patient )
+
         const body = {
             size: 0,
-            query,
+            query: JSON.parse( stringifiedQuery ),
             aggs
         }
 
         console.debug( JSON.stringify( body ) )
+
         return rp( {
             method: 'POST',
             uri,
@@ -282,11 +292,16 @@ export default class ElasticClient {
 
         request.query.bool.filter.push( { term: { [ schema.fields.patient ]: patient } } )
 
+        let stringifiedQuery = JSON.stringify( request.query )
+
+        stringifiedQuery = stringifiedQuery.replace( '%patientId.keyword%', patient )
+
         const body = {
-            query: request.query
+            query: JSON.parse( stringifiedQuery )
         }
 
         console.debug( JSON.stringify( body ) )
+
         return rp( {
             method: 'POST',
             uri,

--- a/src/services/elastic.js
+++ b/src/services/elastic.js
@@ -247,14 +247,14 @@ export default class ElasticClient {
 
         query.bool.filter.push( { term: { [ schema.fields.patient ]: patient } } )
 
-        let stringifiedQuery = JSON.stringify( query )
+        let stringifiedAggs = JSON.stringify( aggs )
 
-        stringifiedQuery = stringifiedQuery.replace( '%patientId.keyword%', patient )
+        stringifiedAggs = stringifiedAggs.replace( '%patientId.keyword%', aggs )
 
         const body = {
             size: 0,
-            query: JSON.parse( stringifiedQuery ),
-            aggs
+            query,
+            aggs: JSON.parse( stringifiedAggs )
         }
 
         console.debug( JSON.stringify( body ) )

--- a/src/services/elastic.js
+++ b/src/services/elastic.js
@@ -102,7 +102,7 @@ export default class ElasticClient {
         let sort = sortDefinition.sort
 
         if ( sortDefinition.postprocess ) {
-            const postprocess = new Function( 'context', sortDefinition.postprocess ) /* eslint-disable-line */
+            const postprocess = new Function( 'context', sortDefinition.postprocess )
             const context = {
                 sort,
                 acl,


### PR DESCRIPTION
Filter configs can now be extended using a special "subtype" attribute to perform additional operations; in this case, support for nested types (this is an extensible format which could support additional extensions later on):

``` {
      "id": "zygosity",
      "label": "category_zygosity",
      "filters": [
        {
          "id": "transmission",
          "label": "filter_transmission",
          "type": "generic",
          // subtype starts here
          "subtype": {
            "type": "nested",
            "config": {
              "path": "donors",
              "field": "patientId.keyword"
            }
          },
          // subtype ends here
          "search": {
            "transmission": "donors.zygosity.keyword"
          },
          "facet": [
            {
              "id": "transmission",
              "query": {
                "terms": {
                  "field": "donors.zygosity.keyword",
                  "order": {
                    "_count": "desc"
                  },
                  "size": 9
                }
              }
            }
          ]
        }
      ]
    },```