### PR TITLE
WIP: Fix transmission and closure bug (see TODO)

### DIFF
--- a/src/services/api/variant/schema/es/1.json
+++ b/src/services/api/variant/schema/es/1.json
@@ -849,35 +849,6 @@
       "label": "category_zygosity",
       "filters": [
         {
-          "id": "zygosity",
-          "label": "filter_zygosity",
-          "type": "generic",
-          "subtype": {
-            "type": "nested",
-            "config": {
-              "path": "donors",
-              "field": "patientId.keyword"
-            }
-          },
-          "search": {
-            "zygosity": "donors.zygosity.keyword"
-          },
-          "facet": [
-            {
-              "id": "zygosity",
-              "query": {
-                "terms": {
-                  "field": "donors.zygosity.keyword",
-                  "order": {
-                    "_count": "desc"
-                  },
-                  "size": 9
-                }
-              }
-            }
-          ]
-        },
-        {
           "id": "transmission",
           "label": "filter_transmission",
           "type": "generic",
@@ -897,6 +868,35 @@
               "query": {
                 "terms": {
                   "field": "donors.transmission.keyword",
+                  "order": {
+                    "_count": "desc"
+                  },
+                  "size": 9
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "zygosity",
+          "label": "filter_zygosity",
+          "type": "generic",
+          "subtype": {
+            "type": "nested",
+            "config": {
+              "path": "donors",
+              "field": "patientId.keyword"
+            }
+          },
+          "search": {
+            "zygosity": "donors.zygosity.keyword"
+          },
+          "facet": [
+            {
+              "id": "zygosity",
+              "query": {
+                "terms": {
+                  "field": "donors.zygosity.keyword",
                   "order": {
                     "_count": "desc"
                   },

--- a/src/services/api/variant/sqon/index.js
+++ b/src/services/api/variant/sqon/index.js
@@ -1,4 +1,4 @@
-import { isArray, filter, find } from 'lodash'
+import { isArray, filter, find, cloneDeep } from 'lodash'
 
 import {
     elasticSearchTranslator,
@@ -234,11 +234,9 @@ const translate = ( statement, queryKey, schema, dialect, dialectOptions ) => {
 
     if ( translator ) {
         const isValid = validateStatement( isArray( statement ) ? statement : [ statement ] )
+
         if ( !isValid ) {
-            // TODO -- Find better approach;
-            //  Right now I don't use the .emptyTranslation because it does not stay 'empty' --  data is push to it and its 'state' (closure) change
-            // return translator.emptyTranslation
-            return { query: { bool: { filter: [] } } }
+            return cloneDeep( translator.emptyTranslation )
         }
         const denormalizedStatement = denormalize( statement )
         const denormalizedQuery = getQueryByKey( denormalizedStatement, queryKey )

--- a/src/services/api/variant/sqon/index.js
+++ b/src/services/api/variant/sqon/index.js
@@ -234,11 +234,12 @@ const translate = ( statement, queryKey, schema, dialect, dialectOptions ) => {
 
     if ( translator ) {
         const isValid = validateStatement( isArray( statement ) ? statement : [ statement ] )
-
         if ( !isValid ) {
-            return translator.emptyTranslation
+            // TODO -- Find better approach;
+            //  Right now I don't use the .emptyTranslation because it does not stay 'empty' --  data is push to it and its 'state' (closure) change
+            // return translator.emptyTranslation
+            return { query: { bool: { filter: [] } } }
         }
-
         const denormalizedStatement = denormalize( statement )
         const denormalizedQuery = getQueryByKey( denormalizedStatement, queryKey )
         const getFieldSearchNameFromFieldId = getFieldSearchNameFromFieldIdMappingFunction( schema )

--- a/src/services/elastic.js
+++ b/src/services/elastic.js
@@ -120,12 +120,12 @@ export default class ElasticClient {
 
             sort = postprocess( context )
         }
-
         if ( filter.length > 0 ) {
             request.query.bool.filter.push( filter )
         }
 
         request.query.bool.filter.push( { term: { [ schema.fields.patient ]: patient } } )
+        // console.debug(`+++ search request.body:${JSON.stringify( request.query )}`  )
 
         const body = {
             from: index,
@@ -134,7 +134,7 @@ export default class ElasticClient {
             sort
         }
 
-        console.debug( JSON.stringify( body ) )
+        console.debug( `search body: ${JSON.stringify( body )}` )
 
         return rp( {
             method: 'POST',
@@ -255,7 +255,7 @@ export default class ElasticClient {
             aggs: replacePlaceholderInJSON( aggs, '%patientId.keyword%', patient )
         }
 
-        console.debug( JSON.stringify( body ) )
+        console.debug( `facet body: ${JSON.stringify( body )}` )
 
         return rp( {
             method: 'POST',
@@ -294,7 +294,7 @@ export default class ElasticClient {
             query: replacePlaceholderInJSON( request.query, '%patientId.keyword%', patient )
         }
 
-        console.debug( JSON.stringify( body ) )
+        console.debug( `count body: ${JSON.stringify( body )}` )
 
         return rp( {
             method: 'POST',


### PR DESCRIPTION
- switch order between zygosity and transmission (seem to have css bu…g that prevent transmission filter to open correctly

- Fix emptyTranslation that does not stay empty
-- Step to reproduce is to go to Variant Interpreter and choose an empty statement for 1 patient then switch to another patient...  The new ES request will contain the previous patientId and the new one...