### PR TITLE
Added support for extra request options when connecting to keycloak

### DIFF
--- a/src/services/keycloak.js
+++ b/src/services/keycloak.js
@@ -6,19 +6,19 @@ export default class KeycloakClient {
     constructor( config ) {
         this.host = config.host
         this.clientId = config.clientId
-        this.clientSecret = config.clientSecret,
+        this.clientSecret = config.clientSecret
         this.extraOptions = config.extraOptions || {}
     }
 
     async ping() {
-        return rp( Object.assign({
+        return rp( Object.assign(this.extraOptions, {
             method: 'GET',
             uri: `${this.host}`
-        }, this.extraOptions) )
+        }) )
     }
 
     async authenticate( username, password ) {
-        return rp( Object.assign({
+        return rp( Object.assign(this.extraOptions, {
             method: 'POST',
             uri: `${this.host}/protocol/openid-connect/token`,
             form: {
@@ -29,11 +29,11 @@ export default class KeycloakClient {
                 client_id: this.clientId,
                 client_secret: this.clientSecret
             }
-        }, this.extraOptions) )
+        }) )
     }
 
     async refresh( token ) {
-        return rp( Object.assign({
+        return rp( Object.assign(this.extraOptions, {
             method: 'POST',
             uri: `${this.host}/protocol/openid-connect/token`,
             form: {
@@ -42,7 +42,7 @@ export default class KeycloakClient {
                 client_id: this.clientId,
                 client_secret: this.clientSecret
             }
-        }, this.extraOptions) )
+        }) )
     }
 
 }

--- a/src/services/keycloak.js
+++ b/src/services/keycloak.js
@@ -6,18 +6,19 @@ export default class KeycloakClient {
     constructor( config ) {
         this.host = config.host
         this.clientId = config.clientId
-        this.clientSecret = config.clientSecret
+        this.clientSecret = config.clientSecret,
+        this.extraOptions = config.extraOptions || {}
     }
 
     async ping() {
-        return rp( {
+        return rp( Object.assign({
             method: 'GET',
             uri: `${this.host}`
-        } )
+        }, this.extraOptions) )
     }
 
     async authenticate( username, password ) {
-        return rp( {
+        return rp( Object.assign({
             method: 'POST',
             uri: `${this.host}/protocol/openid-connect/token`,
             form: {
@@ -28,11 +29,11 @@ export default class KeycloakClient {
                 client_id: this.clientId,
                 client_secret: this.clientSecret
             }
-        } )
+        }, this.extraOptions) )
     }
 
     async refresh( token ) {
-        return rp( {
+        return rp( Object.assign({
             method: 'POST',
             uri: `${this.host}/protocol/openid-connect/token`,
             form: {
@@ -41,7 +42,7 @@ export default class KeycloakClient {
                 client_id: this.clientId,
                 client_secret: this.clientSecret
             }
-        } )
+        }, this.extraOptions) )
     }
 
 }


### PR DESCRIPTION
For my use-case, I needed to disable strict certificate checking for keycloak: https://github.com/cr-ste-justine/clin-proxy-api/blob/feature/overture-orchestration/overture.env#L15

However, more generally, the underlying request library supports a lot of options: https://github.com/request/request#requestoptions-callback

Rather than making a separate PR ad-hoc for each additional option we need in the future, I think it makes sense to just support extra options in the config and pass them to the underlying request library.